### PR TITLE
automatically encode public key contents

### DIFF
--- a/cdn.tf
+++ b/cdn.tf
@@ -96,7 +96,7 @@ resource "aws_cloudfront_distribution" "cdn" {
 
 resource "aws_cloudfront_public_key" "signing" {
   count       = length(var.cloudfront_public_keys)
-  name        = format("%s-%d", module.cdn_label.id, count.index)
-  encoded_key = var.cloudfront_public_keys[count.index]
   comment     = module.cdn_label.id
+  name        = format("%s-%d", module.cdn_label.id, count.index)
+  encoded_key = var.cloudfront_encode_keys ? base64encode(var.cloudfront_public_keys[count.index]) : var.cloudfront_public_keys[count.index]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -117,6 +117,12 @@ variable "cloudfront_public_keys" {
   description = "Public Keys in PEM Format to upload to Cloudfront (for example for URL Signing)"
 }
 
+variable "cloudfront_encode_keys" {
+  type        = bool
+  default     = true
+  description = "Whether to Encode Keys with Base64. Set to false if cloudfront_public_keys are already base64 encoded."
+}
+
 variable "lifecycle_expiration_rules" {
   type        = map(object({ prefix = string, expirationInDays = number }))
   default     = {}


### PR DESCRIPTION
https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html#private-content-uploading-cloudfront-public-key-procedure

public keys uploaded to AWS Cloudfront must be base64 encoded.
Includes the ability to opt-out and pass in already encoded values.