### PR TITLE
allow setting trusted signers for distribution

### DIFF
--- a/cdn.tf
+++ b/cdn.tf
@@ -48,8 +48,8 @@ resource "aws_cloudfront_distribution" "cdn" {
     min_ttl                = var.cloudfront_min_ttl
     max_ttl                = var.cloudfront_max_ttl
     default_ttl            = var.cloudfront_default_ttl
+    trusted_signers        = var.cloudfront_trusted_signers
     viewer_protocol_policy = var.cloudfront_viewer_protocol_policy
-    trusted_signers        = ["self"]
 
     forwarded_values {
       query_string = true

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,12 @@ variable "cloudfront_aliases" {
   description = "Domain Aliases for the Cloudfront Distribution in form of Record Name => Zone Name"
 }
 
+variable "cloudfront_trusted_signers" {
+  type        = list(string)
+  default     = []
+  description = "Trusted AWS Account IDs or Keyword 'self' to allow signing URLs for this Distribution"
+}
+
 variable "cloudfront_comment" {
   type        = string
   default     = ""


### PR DESCRIPTION
this currently also forces signed urls when set to non empty list 